### PR TITLE
ELF linker script: remove ARM specific section

### DIFF
--- a/factory-elf.lds
+++ b/factory-elf.lds
@@ -41,5 +41,5 @@ SECTIONS
     _end = ALIGN(4096);
     PROVIDE (eend = _end);
 
-    /DISCARD/           : { *(.note.*) }
+    /DISCARD/           : { *(.note.*) *(.ARM.exidx) *(.ARM.attributes) }
 }


### PR DESCRIPTION
Clang tends to generate these sections that, in many cases, are useless
in shellcodes and take place.